### PR TITLE
feat: Add Slack notification workflow for pull requests and issues

### DIFF
--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,0 +1,32 @@
+name: Slack Notification
+
+on:
+  workflow_call:
+    secrets:
+      slack-webhook:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.slack-webhook }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            text="🛎️ *New Pull Request Created!*\n*Title:* $PR_TITLE\n*Author:* $ACTOR\n*Link:* <$PR_URL>"
+          elif [[ "$EVENT_NAME" == "issues" ]]; then
+            text="📝 *New Issue Created!*\n*Title:* $ISSUE_TITLE\n*Author:* $ACTOR\n*Link:* <$ISSUE_URL>"
+          else
+            text="⚠️ Unhandled event: $EVENT_NAME"
+          fi
+
+          payload="{\"text\": \"$text\"}"
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to send Slack notifications for pull request and issue creation events.

Notification workflow:

* [`.github/workflows/slack-notify.yaml`](diffhunk://#diff-a7d1be1cac9a56297eab960210b6e58edb477d87e6e616f11f8be9a416ade694R1-R32): Added a new workflow named `Slack Notification` that triggers on `workflow_call` events. It uses a secret `slack-webhook` to send formatted Slack messages based on the event type (`pull_request` or `issues`). The messages include details such as the title, author, and URL of the pull request or issue.