### PR TITLE
ci(slack-notify): add pull_request_target trigger and improve webhook handling

### DIFF
--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -6,6 +6,7 @@ on:
     secrets:
       slack-webhook:
         required: true
+  pull_request_target:
 
 jobs:
   notify:
@@ -13,7 +14,7 @@ jobs:
     steps:
       - name: Send Slack Notification
         env:
-          SLACK_WEBHOOK: ${{ secrets.slack-webhook }}
+          SLACK_WEBHOOK: ${{ secrets['slack-webhook'] }}
           EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -21,6 +22,11 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          if [[ -z "$SLACK_WEBHOOK" ]]; then
+            echo "SLACK_WEBHOOK is empty. Skipping Slack notification."
+            exit 0
+          fi
+
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             text="🛎️ *New Pull Request Created!*\n*Title:* $PR_TITLE\n*Author:* $ACTOR\n*Link:* <$PR_URL>"
           elif [[ "$EVENT_NAME" == "issues" ]]; then


### PR DESCRIPTION
- Add pull_request_target event trigger to workflow
- Update secret reference syntax from ${{ secrets.slack-webhook }} to ${{ secrets['slack-webhook'] }}
- Add validation check to skip notification if SLACK_WEBHOOK is empty
- Improves workflow robustness by handling missing webhook gracefully